### PR TITLE
fix: display micro-c and hi-c data in matrix example

### DIFF
--- a/example/composite_vis/comparative_matrices.py
+++ b/example/composite_vis/comparative_matrices.py
@@ -42,8 +42,13 @@ genes = gos.Data(
     ],
 )
 
-matrix_data = gos.Data(
+micro_c = gos.Data(
     url="https://server.gosling-lang.org/api/v1/tileset_info/?d=hffc6-microc-hg38",
+    type="matrix",
+)
+
+hi_c = gos.Data(
+    url="https://server.gosling-lang.org/api/v1/tileset_info/?d=hffc6-hic-hg38",
     type="matrix",
 )
 
@@ -121,7 +126,7 @@ top = gos.stack(
     gene_overlay.properties(width=size, height=scaled_size),
 )
 
-matrix = gos.Track(matrix_data).mark_rect().encode(
+matrix = gos.Track(micro_c).mark_rect().encode(
     x=gos.Channel("position1:G", axis="none"),
     y=gos.Channel("position2:G", axis="none"),
     color=gos.Channel("value:Q", range="warm"),
@@ -144,9 +149,16 @@ bottom = gos.Track(epilogos_data).mark_bar().encode(
     height=scaled_size,
 )
 
-pane = gos.vertical(top, matrix.view(), bottom.view(), spacing=0)
+left_matrix = gos.vertical(top, matrix.view(), bottom.view(), spacing=0)
+right_matrix = gos.vertical(
+    top,
+    # replace data source for right side, change title
+    matrix.properties(data=hi_c, title="HFFc6_Hi-C").view(),
+    bottom.view(),
+    spacing=0,
+)
 
-right = gos.View(views=[pane, pane], spacing=30)
+right = gos.View(views=[left_matrix, right_matrix], spacing=30)
 
 gos.horizontal(left, right).properties(
     title="Matrix Visualization",


### PR DESCRIPTION
Micro-c data was duplicated originally.