### PR TITLE
feat: infer mixin return type

### DIFF
--- a/gosling/api.py
+++ b/gosling/api.py
@@ -1,3 +1,4 @@
+from typing import TypeVar
 from gosling.schema import Undefined, channels, core, mixins
 from gosling.utils import infer_encoding_types
 from gosling.display import JSRenderer  # , HTMLRenderer
@@ -17,6 +18,8 @@ renderers = {
     "js": JSRenderer(),
 }
 
+T = TypeVar("T")
+
 # Aliases & Utils
 Data = core.DataDeep
 
@@ -26,7 +29,7 @@ def value(value, **kwargs):
 
 
 class _EncodingMixin:
-    def encode(self, *args, **kwargs):
+    def encode(self: T, *args, **kwargs) -> T:
         # Convert args to kwargs based on their types.
         copy = self.copy()
         kwargs = infer_encoding_types(args, kwargs, channels)
@@ -36,7 +39,7 @@ class _EncodingMixin:
 
 
 class _PropertiesMixen:
-    def properties(self, **kwargs):
+    def properties(self: T, **kwargs) -> T:
         copy = self.copy()
         for key, value in kwargs.items():
             setattr(copy, key, value)
@@ -44,53 +47,53 @@ class _PropertiesMixen:
 
 
 class _TransformsMixen:
-    def _add_transform(self, *transforms):
+    def _add_transform(self:T , *transforms) -> T:
         copy = self.copy()
         if copy.dataTransform is Undefined:
             copy.dataTransform = []
         copy.dataTransform.extend(transforms)
         return copy
 
-    def transform_filter(self, field, **kwargs):
+    def transform_filter(self: T, field, **kwargs) -> T:
         return self._add_transform(
             core.FilterTransform(type="filter", field=field, **kwargs)
         )
 
-    def transform_filter_not(self, field, **kwargs):
+    def transform_filter_not(self: T, field, **kwargs) -> T:
         kwargs["not"] = True
         return self._add_transform(
             core.FilterTransform(type="filter", field=field, **kwargs)
         )
 
-    def transform_log(self, field, **kwargs):
+    def transform_log(self: T, field, **kwargs) -> T:
         return self._add_transform(
             core.LogTransform(type="log", field=field, **kwargs),
         )
 
-    def transform_str_concat(self, fields, **kwargs):
+    def transform_str_concat(self: T, fields, **kwargs) -> T:
         return self._add_transform(
             core.StrConcatTransform(type="concat", fields=fields, **kwargs),
         )
 
-    def transform_str_replace(self, field, **kwargs):
+    def transform_str_replace(self: T, field, **kwargs) -> T:
         return self._add_transform(
             core.StrReplaceTransform(type="replace", field=field, **kwargs)
         )
 
-    def transform_displace(self, **kwargs):
+    def transform_displace(self: T, **kwargs) -> T:
         return self._add_transform(core.DisplaceTransform(type="displace", **kwargs))
 
-    def transform_exon_split(self, **kwargs):
+    def transform_exon_split(self: T, **kwargs) -> T:
         return self._add_transform(core.ExonSplitTransform(type="exonSplit", **kwargs))
 
-    def transform_coverage(self, startField, endField, **kwargs):
+    def transform_coverage(self: T, startField, endField, **kwargs) -> T:
         return self._add_transform(
             core.CoverageTransform(
                 type="coverage", startField=startField, endField=endField, **kwargs
             )
         )
 
-    def transform_json_parse(self, field, **kwargs):
+    def transform_json_parse(self: T, field, **kwargs) -> T:
         return self._add_transform(
             core.JSONParseTransform(type="subjson", field=field, **kwargs)
         )

--- a/gosling/schema/mixins.py
+++ b/gosling/schema/mixins.py
@@ -2,18 +2,20 @@
 # tools/generate_schema_wrapper.py. Do not modify directly.
 from . import core
 from gosling.schemapi import Undefined
+from typing import TypeVar
 
 
+T = TypeVar('T')
 class MarkMethodMixin(object):
     """A mixin class that defines mark methods"""
 
-    def mark_point(self, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
+    def mark_point(self: T, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
                    bazierLink=Undefined, circularLink=Undefined, curve=Undefined, dashed=Undefined,
                    dx=Undefined, dy=Undefined, enableSmoothPath=Undefined, inlineLegend=Undefined,
                    legendTitle=Undefined, linePattern=Undefined, linkConnectionType=Undefined,
                    outline=Undefined, outlineWidth=Undefined, textAnchor=Undefined,
                    textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                   textStrokeWidth=Undefined, **kwds):
+                   textStrokeWidth=Undefined, **kwds) -> T:
         """Set the chart's mark to 'point'
     
         For information on additional arguments, see :class:`Style`
@@ -31,13 +33,13 @@ class MarkMethodMixin(object):
             copy.style = core.Style(**kwds)
         return copy
 
-    def mark_line(self, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
+    def mark_line(self: T, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
                   bazierLink=Undefined, circularLink=Undefined, curve=Undefined, dashed=Undefined,
                   dx=Undefined, dy=Undefined, enableSmoothPath=Undefined, inlineLegend=Undefined,
                   legendTitle=Undefined, linePattern=Undefined, linkConnectionType=Undefined,
                   outline=Undefined, outlineWidth=Undefined, textAnchor=Undefined,
                   textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                  textStrokeWidth=Undefined, **kwds):
+                  textStrokeWidth=Undefined, **kwds) -> T:
         """Set the chart's mark to 'line'
     
         For information on additional arguments, see :class:`Style`
@@ -55,13 +57,13 @@ class MarkMethodMixin(object):
             copy.style = core.Style(**kwds)
         return copy
 
-    def mark_area(self, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
+    def mark_area(self: T, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
                   bazierLink=Undefined, circularLink=Undefined, curve=Undefined, dashed=Undefined,
                   dx=Undefined, dy=Undefined, enableSmoothPath=Undefined, inlineLegend=Undefined,
                   legendTitle=Undefined, linePattern=Undefined, linkConnectionType=Undefined,
                   outline=Undefined, outlineWidth=Undefined, textAnchor=Undefined,
                   textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                  textStrokeWidth=Undefined, **kwds):
+                  textStrokeWidth=Undefined, **kwds) -> T:
         """Set the chart's mark to 'area'
     
         For information on additional arguments, see :class:`Style`
@@ -79,13 +81,13 @@ class MarkMethodMixin(object):
             copy.style = core.Style(**kwds)
         return copy
 
-    def mark_bar(self, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
+    def mark_bar(self: T, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
                  bazierLink=Undefined, circularLink=Undefined, curve=Undefined, dashed=Undefined,
                  dx=Undefined, dy=Undefined, enableSmoothPath=Undefined, inlineLegend=Undefined,
                  legendTitle=Undefined, linePattern=Undefined, linkConnectionType=Undefined,
                  outline=Undefined, outlineWidth=Undefined, textAnchor=Undefined,
                  textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                 textStrokeWidth=Undefined, **kwds):
+                 textStrokeWidth=Undefined, **kwds) -> T:
         """Set the chart's mark to 'bar'
     
         For information on additional arguments, see :class:`Style`
@@ -103,13 +105,13 @@ class MarkMethodMixin(object):
             copy.style = core.Style(**kwds)
         return copy
 
-    def mark_rect(self, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
+    def mark_rect(self: T, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
                   bazierLink=Undefined, circularLink=Undefined, curve=Undefined, dashed=Undefined,
                   dx=Undefined, dy=Undefined, enableSmoothPath=Undefined, inlineLegend=Undefined,
                   legendTitle=Undefined, linePattern=Undefined, linkConnectionType=Undefined,
                   outline=Undefined, outlineWidth=Undefined, textAnchor=Undefined,
                   textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                  textStrokeWidth=Undefined, **kwds):
+                  textStrokeWidth=Undefined, **kwds) -> T:
         """Set the chart's mark to 'rect'
     
         For information on additional arguments, see :class:`Style`
@@ -127,13 +129,13 @@ class MarkMethodMixin(object):
             copy.style = core.Style(**kwds)
         return copy
 
-    def mark_text(self, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
+    def mark_text(self: T, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
                   bazierLink=Undefined, circularLink=Undefined, curve=Undefined, dashed=Undefined,
                   dx=Undefined, dy=Undefined, enableSmoothPath=Undefined, inlineLegend=Undefined,
                   legendTitle=Undefined, linePattern=Undefined, linkConnectionType=Undefined,
                   outline=Undefined, outlineWidth=Undefined, textAnchor=Undefined,
                   textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                  textStrokeWidth=Undefined, **kwds):
+                  textStrokeWidth=Undefined, **kwds) -> T:
         """Set the chart's mark to 'text'
     
         For information on additional arguments, see :class:`Style`
@@ -151,13 +153,13 @@ class MarkMethodMixin(object):
             copy.style = core.Style(**kwds)
         return copy
 
-    def mark_withinLink(self, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
+    def mark_withinLink(self: T, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
                         bazierLink=Undefined, circularLink=Undefined, curve=Undefined, dashed=Undefined,
                         dx=Undefined, dy=Undefined, enableSmoothPath=Undefined, inlineLegend=Undefined,
                         legendTitle=Undefined, linePattern=Undefined, linkConnectionType=Undefined,
                         outline=Undefined, outlineWidth=Undefined, textAnchor=Undefined,
                         textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                        textStrokeWidth=Undefined, **kwds):
+                        textStrokeWidth=Undefined, **kwds) -> T:
         """Set the chart's mark to 'withinLink'
     
         For information on additional arguments, see :class:`Style`
@@ -175,13 +177,13 @@ class MarkMethodMixin(object):
             copy.style = core.Style(**kwds)
         return copy
 
-    def mark_betweenLink(self, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
+    def mark_betweenLink(self: T, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
                          bazierLink=Undefined, circularLink=Undefined, curve=Undefined,
                          dashed=Undefined, dx=Undefined, dy=Undefined, enableSmoothPath=Undefined,
                          inlineLegend=Undefined, legendTitle=Undefined, linePattern=Undefined,
                          linkConnectionType=Undefined, outline=Undefined, outlineWidth=Undefined,
                          textAnchor=Undefined, textFontSize=Undefined, textFontWeight=Undefined,
-                         textStroke=Undefined, textStrokeWidth=Undefined, **kwds):
+                         textStroke=Undefined, textStrokeWidth=Undefined, **kwds) -> T:
         """Set the chart's mark to 'betweenLink'
     
         For information on additional arguments, see :class:`Style`
@@ -199,13 +201,13 @@ class MarkMethodMixin(object):
             copy.style = core.Style(**kwds)
         return copy
 
-    def mark_rule(self, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
+    def mark_rule(self: T, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
                   bazierLink=Undefined, circularLink=Undefined, curve=Undefined, dashed=Undefined,
                   dx=Undefined, dy=Undefined, enableSmoothPath=Undefined, inlineLegend=Undefined,
                   legendTitle=Undefined, linePattern=Undefined, linkConnectionType=Undefined,
                   outline=Undefined, outlineWidth=Undefined, textAnchor=Undefined,
                   textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                  textStrokeWidth=Undefined, **kwds):
+                  textStrokeWidth=Undefined, **kwds) -> T:
         """Set the chart's mark to 'rule'
     
         For information on additional arguments, see :class:`Style`
@@ -223,13 +225,13 @@ class MarkMethodMixin(object):
             copy.style = core.Style(**kwds)
         return copy
 
-    def mark_triangleLeft(self, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
+    def mark_triangleLeft(self: T, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
                           bazierLink=Undefined, circularLink=Undefined, curve=Undefined,
                           dashed=Undefined, dx=Undefined, dy=Undefined, enableSmoothPath=Undefined,
                           inlineLegend=Undefined, legendTitle=Undefined, linePattern=Undefined,
                           linkConnectionType=Undefined, outline=Undefined, outlineWidth=Undefined,
                           textAnchor=Undefined, textFontSize=Undefined, textFontWeight=Undefined,
-                          textStroke=Undefined, textStrokeWidth=Undefined, **kwds):
+                          textStroke=Undefined, textStrokeWidth=Undefined, **kwds) -> T:
         """Set the chart's mark to 'triangleLeft'
     
         For information on additional arguments, see :class:`Style`
@@ -247,13 +249,13 @@ class MarkMethodMixin(object):
             copy.style = core.Style(**kwds)
         return copy
 
-    def mark_triangleRight(self, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
+    def mark_triangleRight(self: T, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
                            bazierLink=Undefined, circularLink=Undefined, curve=Undefined,
                            dashed=Undefined, dx=Undefined, dy=Undefined, enableSmoothPath=Undefined,
                            inlineLegend=Undefined, legendTitle=Undefined, linePattern=Undefined,
                            linkConnectionType=Undefined, outline=Undefined, outlineWidth=Undefined,
                            textAnchor=Undefined, textFontSize=Undefined, textFontWeight=Undefined,
-                           textStroke=Undefined, textStrokeWidth=Undefined, **kwds):
+                           textStroke=Undefined, textStrokeWidth=Undefined, **kwds) -> T:
         """Set the chart's mark to 'triangleRight'
     
         For information on additional arguments, see :class:`Style`
@@ -271,13 +273,13 @@ class MarkMethodMixin(object):
             copy.style = core.Style(**kwds)
         return copy
 
-    def mark_triangleBottom(self, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
+    def mark_triangleBottom(self: T, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
                             bazierLink=Undefined, circularLink=Undefined, curve=Undefined,
                             dashed=Undefined, dx=Undefined, dy=Undefined, enableSmoothPath=Undefined,
                             inlineLegend=Undefined, legendTitle=Undefined, linePattern=Undefined,
                             linkConnectionType=Undefined, outline=Undefined, outlineWidth=Undefined,
                             textAnchor=Undefined, textFontSize=Undefined, textFontWeight=Undefined,
-                            textStroke=Undefined, textStrokeWidth=Undefined, **kwds):
+                            textStroke=Undefined, textStrokeWidth=Undefined, **kwds) -> T:
         """Set the chart's mark to 'triangleBottom'
     
         For information on additional arguments, see :class:`Style`
@@ -295,13 +297,13 @@ class MarkMethodMixin(object):
             copy.style = core.Style(**kwds)
         return copy
 
-    def mark_brush(self, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
+    def mark_brush(self: T, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
                    bazierLink=Undefined, circularLink=Undefined, curve=Undefined, dashed=Undefined,
                    dx=Undefined, dy=Undefined, enableSmoothPath=Undefined, inlineLegend=Undefined,
                    legendTitle=Undefined, linePattern=Undefined, linkConnectionType=Undefined,
                    outline=Undefined, outlineWidth=Undefined, textAnchor=Undefined,
                    textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                   textStrokeWidth=Undefined, **kwds):
+                   textStrokeWidth=Undefined, **kwds) -> T:
         """Set the chart's mark to 'brush'
     
         For information on additional arguments, see :class:`Style`
@@ -319,13 +321,13 @@ class MarkMethodMixin(object):
             copy.style = core.Style(**kwds)
         return copy
 
-    def mark_header(self, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
+    def mark_header(self: T, align=Undefined, background=Undefined, backgroundOpacity=Undefined,
                     bazierLink=Undefined, circularLink=Undefined, curve=Undefined, dashed=Undefined,
                     dx=Undefined, dy=Undefined, enableSmoothPath=Undefined, inlineLegend=Undefined,
                     legendTitle=Undefined, linePattern=Undefined, linkConnectionType=Undefined,
                     outline=Undefined, outlineWidth=Undefined, textAnchor=Undefined,
                     textFontSize=Undefined, textFontWeight=Undefined, textStroke=Undefined,
-                    textStrokeWidth=Undefined, **kwds):
+                    textStrokeWidth=Undefined, **kwds) -> T:
         """Set the chart's mark to 'header'
     
         For information on additional arguments, see :class:`Style`

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -321,7 +321,7 @@ def generate_channel_wrappers(schemafile, imports=None):
 
 
 MARK_METHOD = '''
-def mark_{mark}({def_arglist}):
+def mark_{mark}({def_arglist}) -> T:
     """Set the chart's mark to '{mark}'
 
     For information on additional arguments, see :class:`{style_def}`
@@ -341,9 +341,14 @@ def generate_mark_mixin(
     with open(schemafile, encoding="utf8") as f:
         schema = json.load(f)
 
-    imports = ["from gosling.schemapi import Undefined", "from . import core"]
+    imports = [
+        "from typing import TypeVar",
+        "from gosling.schemapi import Undefined",
+        "from . import core",
+    ]
 
     code = [
+        "T = TypeVar('T')",
         "class MarkMethodMixin(object):",
         '    """A mixin class that defines mark methods"""',
     ]
@@ -356,7 +361,7 @@ def generate_mark_mixin(
     required -= {"type"}
     kwds -= {"type"}
 
-    def_args = ["self"] + [
+    def_args = ["self: T"] + [
         "{}=Undefined".format(p) for p in (sorted(required) + sorted(kwds))
     ]
     dict_args = ["{0}={0}".format(p) for p in (sorted(required) + sorted(kwds))]


### PR DESCRIPTION
Right now the mixin methods obfuscate the type (which should be the same as `self`). This PR adds a generic type parameter to self for the mixin methods so that the return type can be inferred.

### Before:

```python
import gosling as gos

track = gos.Track(...) # track is type `Track`

track = gos.Track(...).mark_brush() # track is type `Unknown`

track = gos.Track(...).mark_brush().encode(...) # track is type `Unknown`
```

### After:

```python
import gosling as gos

track = gos.Track(...) # track is type `Track`

track = gos.Track(...).mark_brush() # track is type `Track`

track = gos.Track(...).mark_brush().encode(...) # track is type `Track`
```