### PR TITLE
feat: add circular overview + detail example

### DIFF
--- a/example/overview_detail.py
+++ b/example/overview_detail.py
@@ -1,0 +1,84 @@
+import gosling as gos
+
+multivec_data = gos.Data(
+    url="https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
+    type="multivec",
+    row="sample",
+    column="position",
+    value="peak",
+    categories=["sample 1", "sample 2", "sample 3", "sample 4"],
+    binSize=4,
+)
+
+rearrangments = gos.Data(
+    url="https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/rearrangements.bulk.1639.simple.filtered.pub",
+    type="csv",
+    headerNames=["chr1", "p1s", "p1e", "chr2", "p2s", "p2e", "type", "id", "f1", "f2", "f3", "f4", "f5", "f6"],
+    separator="\t",
+    genomicFieldsToConvert=[
+        {"chromosomeField": "chr1", "genomicFields": ["p1s", "p1e"]},
+        {"chromosomeField": "chr2", "genomicFields": ["p2s", "p2e"]},
+    ],
+)
+
+base = gos.Track(multivec_data).mark_bar(outlineWidth=0).encode(
+    x="start:G",
+    xe="end:G",
+    y="peak:Q",
+    row="sample:N",
+    color="sample:N",
+    stroke=gos.value("black"),
+    strokeWidth=gos.value(0.3),
+)
+
+circular = gos.stack(
+    (
+        gos.overlay(
+            base.mark_bar(),
+            base.mark_brush().encode(
+                x=gos.Channel("start:G", linkingId="detail-1"),
+                color=gos.value("blue")
+            ),
+            base.mark_brush().encode(
+                x=gos.Channel("start:G", linkingId="detail-2"),
+                color=gos.value("red")
+            ),
+        ).properties(width=500, height=100)
+    ),
+    (
+        gos.Track(rearrangments)
+            .mark_withinLink()
+            .encode(
+                x="p1s:G",
+                xe="p1e:G",
+                x1="p2s:G",
+                x1e="p2e:G",
+                stroke=gos.Channel(
+                    "type:N",
+                    domain=["deletion", "inversion", "translocation", "tandem-duplication"],
+                ),
+                strokeWidth=gos.value(0.8),
+                opacity=gos.value(0.15),
+            )
+            .transform_filter("chr1", oneOf=["1", "16", "14", "9", "6", "5", "3"])
+            .transform_filter("chr2", oneOf=["1", "16", "14", "9", "6", "5", "3"])
+            .properties(width=500, height=100)
+    ),
+).properties(static=True, layout="circular")
+
+
+def detail(background, linkingId, legend, chromosome):
+    domain = gos.Domain(chromosome=chromosome)
+    return base.mark_bar(background=background, backgroundOpacity=0.1).encode(
+        x=gos.Channel("start:G", linkingId=linkingId, domain=domain),
+        strokeWidth=gos.value(0.3),
+        color=gos.Channel("sample:N", legend=legend),
+    ).properties(width=245, height=150)
+
+details = gos.horizontal(
+    detail("blue", "detail-1", legend=False, chromosome="5"),
+    detail("red", "detail-2", legend=True, chromosome="16"),
+    spacing=10,
+)
+
+gos.vertical(circular, details)

--- a/example/routes.json
+++ b/example/routes.json
@@ -6,5 +6,6 @@
     { "file": "area_chart", "title": "Area Chart" },
     { "file": "ideograms", "title": "Ideograms" },
     { "file": "multiscale_sequence", "title": "Multiscale Sequence" },
-    { "file": "comparative_matrices", "title": "Comparative Matrices" }
+    { "file": "comparative_matrices", "title": "Comparative Matrices" },
+    { "file": "overview_detail", "title": "Circular Overview + Detail" }
 ]


### PR DESCRIPTION
Adds [Overview + Detail](https://gosling.js.org/?example=CIRCULAR_OVERVIEW_LINEAR_DETAIL) example. 

<img width="500" alt="image" src="https://user-images.githubusercontent.com/24403730/130653085-9b545fca-c9c4-43c8-9630-0493a0edb04a.png">
