### PR TITLE
feat: add `.visibility_{lt,gt,le,ge}` mixin methods

### DIFF
--- a/example/genes.py
+++ b/example/genes.py
@@ -55,8 +55,7 @@ geneLabel = base.mark_text(dy=15).encode(
     size=gos.value(15)
 ).transform_filter(
     field="type", oneOf=["gene"]
-).visibility(
-    operation="less-than",
+).visibility_lt(
     measure="width",
     threshold="|xe-x|",
     transitionPadding=10,

--- a/example/genes.py
+++ b/example/genes.py
@@ -55,16 +55,12 @@ geneLabel = base.mark_text(dy=15).encode(
     size=gos.value(15)
 ).transform_filter(
     field="type", oneOf=["gene"]
-).properties(
-    visibility=[
-        gos.VisibilityCondition(
-          operation="less-than",
-          measure="width",
-          threshold="|xe-x|",
-          transitionPadding=10,
-          target="mark"
-        )
-    ]
+).visibility(
+    operation="less-than",
+    measure="width",
+    threshold="|xe-x|",
+    transitionPadding=10,
+    target="mark",
 )
 
 exon = base.mark_rect().encode(

--- a/example/multiscale-lolipop-plot.py
+++ b/example/multiscale-lolipop-plot.py
@@ -35,13 +35,13 @@ lolipop = gos.overlay(
             stroke=gos.value("lightgray"),
             strokeWidth=gos.value(1),
             opacity=gos.value(0.3),
-        ).properties(visibility=[{
-            "measure": "zoomLevel",
-            "target": "mark",
-            "threshold": 100000,
-            "operation": "LT",
-            "transitionPadding": 100000
-        }])
+        ).visibility(
+            measure="zoomLevel",
+            target="mark",
+            threshold=100000,
+            operation="LT",
+            transitionPadding=100000,
+        )
     ),
     (
         gos.Track(clin_var_beddb).mark_point().encode(
@@ -50,13 +50,13 @@ lolipop = gos.overlay(
             row=gos.Channel("significance:N", domain=categories),
             size=gos.value(7),
             opacity=gos.value(0.8),
-        ).properties(visibility=[{
-            "measure": "zoomLevel",
-            "target": "mark",
-            "threshold": 1000000,
-            "operation": "LT",
-            "transitionPadding": 1000000
-        }])
+        ).visibility(
+            measure="zoomLevel",
+            target="mark",
+            threshold=1000000,
+            operation="LT",
+            transitionPadding=1000000,
+        )
     ),
     (
         gos.Track(clin_var_multivec).mark_bar().encode(
@@ -64,13 +64,13 @@ lolipop = gos.overlay(
             xe="end:G",
             y=gos.Channel("count:Q", axis="none"),
             color=gos.Channel("significance:N", domain=categories, range=colors, legend=True)
-        ).properties(visibility=[{
-            "measure": "zoomLevel",
-            "target": "mark",
-            "threshold": 500000,
-            "operation": "GT",
-            "transitionPadding": 500000
-        }])
+        ).visibility(
+            measure="zoomLevel",
+            target="mark",
+            threshold=500000,
+            operation="GT",
+            transitionPadding=500000
+        )
     ),
     width=800,
     height=150,

--- a/example/multiscale-lolipop-plot.py
+++ b/example/multiscale-lolipop-plot.py
@@ -35,11 +35,10 @@ lolipop = gos.overlay(
             stroke=gos.value("lightgray"),
             strokeWidth=gos.value(1),
             opacity=gos.value(0.3),
-        ).visibility(
+        ).visibility_lt(
             measure="zoomLevel",
             target="mark",
             threshold=100000,
-            operation="LT",
             transitionPadding=100000,
         )
     ),
@@ -50,11 +49,10 @@ lolipop = gos.overlay(
             row=gos.Channel("significance:N", domain=categories),
             size=gos.value(7),
             opacity=gos.value(0.8),
-        ).visibility(
+        ).visibility_lt(
             measure="zoomLevel",
             target="mark",
             threshold=1000000,
-            operation="LT",
             transitionPadding=1000000,
         )
     ),
@@ -64,12 +62,11 @@ lolipop = gos.overlay(
             xe="end:G",
             y=gos.Channel("count:Q", axis="none"),
             color=gos.Channel("significance:N", domain=categories, range=colors, legend=True)
-        ).visibility(
+        ).visibility_gt(
             measure="zoomLevel",
             target="mark",
             threshold=500000,
-            operation="GT",
-            transitionPadding=500000
+            transitionPadding=500000,
         )
     ),
     width=800,

--- a/example/multiscale-lollipop-plot.py
+++ b/example/multiscale-lollipop-plot.py
@@ -13,7 +13,7 @@ categories = [
     "Pathogenic/Likely_pathogenic", "Pathogenic",
 ]
 
-colors = ["#5A9F8C", "#029F73", "gray", "#CB96B3", "#CB71A3", "#CB3B8C"]
+colors = ["#5A9F8C", "#5A9F8C", "#029F73", "gray", "#CB96B3", "#CB71A3", "#CB3B8C"]
 
 clin_var_multivec = multivec(
     url="https://server.gosling-lang.org/api/v1/tileset_info/?d=clinvar-multivec",

--- a/example/multiscale_sequence.py
+++ b/example/multiscale_sequence.py
@@ -15,10 +15,10 @@ text = gos.Track(data).mark_text().encode(
     size=gos.value(24),
     color=gos.value("white"),
     text="base:N",
-    visibility=[
-        gos.VisibilityCondition(operation="LT", measure="width", threshold="|xe-x|", transitionPadding=30, target="mark"),
-        gos.VisibilityCondition(operation="LT", measure="zoomLevel", threshold=10, target="track")
-    ]
+).visibility(
+    operation="LT", measure="width", threshold="|xe-x|", transitionPadding=30, target="mark"
+).visibility(
+    operation="LT", measure="zoomLevel", threshold=10, target="track"
 ).transform_filter_not("count", oneOf=[0])
 
 bar = gos.Track(data).mark_bar().encode(

--- a/example/multiscale_sequence.py
+++ b/example/multiscale_sequence.py
@@ -15,10 +15,10 @@ text = gos.Track(data).mark_text().encode(
     size=gos.value(24),
     color=gos.value("white"),
     text="base:N",
-).visibility(
-    operation="LT", measure="width", threshold="|xe-x|", transitionPadding=30, target="mark"
-).visibility(
-    operation="LT", measure="zoomLevel", threshold=10, target="track"
+).visibility_lt(
+    measure="width", threshold="|xe-x|", transitionPadding=30, target="mark"
+).visibility_lt(
+    measure="zoomLevel", threshold=10, target="track"
 ).transform_filter_not("count", oneOf=[0])
 
 bar = gos.Track(data).mark_bar().encode(

--- a/gosling/api.py
+++ b/gosling/api.py
@@ -108,19 +108,19 @@ class _VisibilityMixin:
         return copy
 
     def visibility_lt(self: T, **kwargs) -> T:
-        return self._add_visibility(core.VisibilityCondition(condition="LT", **kwargs))
+        return self._add_visibility(core.VisibilityCondition(operation="LT", **kwargs))
 
     def visibility_gt(self: T, **kwargs) -> T:
-        return self._add_visibility(core.VisibilityCondition(condition="GT", **kwargs))
+        return self._add_visibility(core.VisibilityCondition(operation="GT", **kwargs))
 
     def visibility_le(self: T, **kwargs) -> T:
         return self._add_visibility(
-            core.VisibilityCondition(condition="LTET", **kwargs)
+            core.VisibilityCondition(operation="LTET", **kwargs)
         )
 
     def visibility_ge(self: T, **kwargs) -> T:
         return self._add_visibility(
-            core.VisibilityCondition(condition="GTET", **kwargs)
+            core.VisibilityCondition(operation="GTET", **kwargs)
         )
 
 

--- a/gosling/api.py
+++ b/gosling/api.py
@@ -38,7 +38,7 @@ class _EncodingMixin:
         return copy
 
 
-class _PropertiesMixen:
+class _PropertiesMixin:
     def properties(self: T, **kwargs) -> T:
         copy = self.copy()
         for key, value in kwargs.items():
@@ -46,7 +46,7 @@ class _PropertiesMixen:
         return copy
 
 
-class _TransformsMixen:
+class _TransformsMixin:
     def _add_transform(self: T, *transforms) -> T:
         copy = self.copy()
         if copy.dataTransform is Undefined:
@@ -99,7 +99,7 @@ class _TransformsMixen:
         )
 
 
-class _VisibilityMixen:
+class _VisibilityMixin:
     def visibility(self: T, **kwargs) -> T:
         copy = self.copy()
         if copy.visibility is Undefined:
@@ -108,7 +108,7 @@ class _VisibilityMixen:
         return copy
 
 
-class View(_PropertiesMixen, core.Root):
+class View(_PropertiesMixin, core.Root):
     def _repr_mimebundle_(self, include=None, exclude=None):
         dct = self.to_dict()
         renderer = renderers.get("js")
@@ -177,9 +177,9 @@ def stack(*tracks, **kwargs):
 
 class Track(
     _EncodingMixin,
-    _PropertiesMixen,
-    _TransformsMixen,
-    _VisibilityMixen,
+    _PropertiesMixin,
+    _TransformsMixin,
+    _VisibilityMixin,
     mixins.MarkMethodMixin,
     core.SingleTrack,
 ):

--- a/gosling/api.py
+++ b/gosling/api.py
@@ -100,12 +100,15 @@ class _TransformsMixin:
 
 
 class _VisibilityMixin:
-    def visibility(self: T, **kwargs) -> T:
+    def _add_visibility(self: T, *visibilities) -> T:
         copy = self.copy()
         if copy.visibility is Undefined:
             copy.visibility = []
-        copy.visibility.extend(core.VisibilityCondition(**kwargs))
+        copy.visibility.extend(visibilities)
         return copy
+
+    def visibility(self: T, **kwargs) -> T:
+        return self._add_visibility(core.VisibilityCondition(**kwargs))
 
 
 class View(_PropertiesMixin, core.Root):

--- a/gosling/api.py
+++ b/gosling/api.py
@@ -107,8 +107,21 @@ class _VisibilityMixin:
         copy.visibility.extend(visibilities)
         return copy
 
-    def visibility(self: T, **kwargs) -> T:
-        return self._add_visibility(core.VisibilityCondition(**kwargs))
+    def visibility_lt(self: T, **kwargs) -> T:
+        return self._add_visibility(core.VisibilityCondition(condition="LT", **kwargs))
+
+    def visibility_gt(self: T, **kwargs) -> T:
+        return self._add_visibility(core.VisibilityCondition(condition="GT", **kwargs))
+
+    def visibility_le(self: T, **kwargs) -> T:
+        return self._add_visibility(
+            core.VisibilityCondition(condition="LTET", **kwargs)
+        )
+
+    def visibility_ge(self: T, **kwargs) -> T:
+        return self._add_visibility(
+            core.VisibilityCondition(condition="GTET", **kwargs)
+        )
 
 
 class View(_PropertiesMixin, core.Root):

--- a/gosling/api.py
+++ b/gosling/api.py
@@ -99,6 +99,15 @@ class _TransformsMixen:
         )
 
 
+class _VisibilityMixen:
+    def visibility(self: T, **kwargs) -> T:
+        copy = self.copy()
+        if copy.visibility is Undefined:
+            copy.visibility = []
+        copy.visibility.extend(core.VisibilityCondition(**kwargs))
+        return copy
+
+
 class View(_PropertiesMixen, core.Root):
     def _repr_mimebundle_(self, include=None, exclude=None):
         dct = self.to_dict()
@@ -170,6 +179,7 @@ class Track(
     _EncodingMixin,
     _PropertiesMixen,
     _TransformsMixen,
+    _VisibilityMixen,
     mixins.MarkMethodMixin,
     core.SingleTrack,
 ):

--- a/gosling/tests/test_api.py
+++ b/gosling/tests/test_api.py
@@ -1,0 +1,197 @@
+import pytest
+
+import gosling as gos
+
+
+@pytest.fixture
+def basic_track() -> gos.Track:
+    data = gos.Data(
+        url="http://localhost:8080/data.csv",
+        type="csv",
+        chromosomeField="Chromosome",
+        genomicFields=["chromStart", "chromEnd"],
+    )
+    return (
+        gos.Track(data)
+        .mark_line()
+        .encode(
+            x=gos.Channel("position:G", axis="top"),
+            y="peak:Q",
+        )
+    )
+
+
+def test_value() -> None:
+    assert gos.value(1) == {"value": 1}
+    assert gos.value("hello") == {"value": "hello"}
+
+
+def test_basic_view(basic_track: gos.Track) -> None:
+    view = basic_track.view()
+    assert isinstance(view, gos.View)
+    assert view.to_dict() == {"tracks": [basic_track.to_dict()]}
+
+
+def test_transforms(basic_track: gos.Track) -> None:
+    # filter transform
+    track = basic_track.transform_filter("position", oneOf=["+"])
+    kwds = dict(type="filter", field="position", oneOf=["+"])
+    assert track.dataTransform == [gos.FilterTransform(**kwds)]
+    assert not isinstance(basic_track.dataTransform, list)
+
+    # filter transform not
+    track = basic_track.transform_filter_not("position", oneOf=["+"])
+    kwds = {"type": "filter", "field": "position", "not": True, "oneOf": ["+"]}
+    assert track.dataTransform == [gos.FilterTransform(**kwds)]
+
+    # transform log
+    track = basic_track.transform_log("peak")
+    kwds = {"type": "log", "field": "peak"}
+    assert track.dataTransform == [gos.LogTransform(**kwds)]
+
+    # transform string concat
+    track = basic_track.transform_str_concat(
+        ["position", "peak"], newField="z", separator="-"
+    )
+    kwds = dict(type="concat", fields=["position", "peak"], newField="z", separator="-")
+    assert track.dataTransform == [gos.StrConcatTransform(**kwds)]
+
+    # transform string replace
+    replace = [{"from": "x", "to": "y"}]
+    track = basic_track.transform_str_replace("position", newField="z", replace=replace)
+    kwds = dict(type="replace", field="position", newField="z", replace=replace)
+    assert track.dataTransform == [gos.StrReplaceTransform(**kwds)]
+
+    # transform displace
+    bounding_box = {"startField": "peak", "endField": "peak"}
+    track = basic_track.transform_displace(
+        boundingBox=bounding_box, newField="z", method="pile"
+    )
+    kwds = dict(type="displace", boundingBox=bounding_box, newField="z", method="pile")
+    assert track.dataTransform == [gos.DisplaceTransform(**kwds)]
+
+    # transform exon split
+    field = dict(field="peak", type="quantitative", newField="z", chrField="position")
+    track = basic_track.transform_exon_split(
+        separator="-", flag={"field": "peak", "value": 10}, fields=[field]
+    )
+    kwds = dict(
+        type="exonSplit",
+        separator="-",
+        flag={"field": "peak", "value": 10},
+        fields=[field],
+    )
+    assert track.dataTransform == [gos.ExonSplitTransform(**kwds)]
+
+    # transform coverage
+    track = basic_track.transform_coverage("x", "xe")
+    kwds = dict(type="coverage", startField="x", endField="xe")
+    assert track.dataTransform == [gos.CoverageTransform(**kwds)]
+
+    # transform json parse
+    track = basic_track.transform_json_parse(
+        "z", baseGenomicField="x", genomicField="xx", genomicLengthField="xxx"
+    )
+    kwds = dict(
+        type="subjson",
+        field="z",
+        baseGenomicField="x",
+        genomicField="xx",
+        genomicLengthField="xxx",
+    )
+    assert track.dataTransform == [gos.JSONParseTransform(**kwds)]
+
+
+def test_chained_transforms(basic_track: gos.Track) -> None:
+    track = basic_track.transform_filter("position", oneOf=["+"]).transform_filter_not(
+        "position", oneOf=["-"]
+    )
+    assert not isinstance(basic_track.dataTransform, list)
+    assert len(track.dataTransform) == 2
+    assert "not" in track.dataTransform[1].to_dict()
+
+
+def test_visibilities(basic_track: gos.Track) -> None:
+    track = basic_track.visibility_lt(target="track", measure="width", threshold=10)
+    kwds = dict(operation="LT", target="track", measure="width", threshold=10)
+    assert track.visibility == [gos.VisibilityCondition(**kwds)]
+
+    track = basic_track.visibility_gt(target="track", measure="width", threshold=10)
+    kwds = dict(operation="GT", target="track", measure="width", threshold=10)
+    assert track.visibility == [gos.VisibilityCondition(**kwds)]
+
+    track = basic_track.visibility_le(target="track", measure="width", threshold=10)
+    kwds = dict(operation="LTET", target="track", measure="width", threshold=10)
+    assert track.visibility == [gos.VisibilityCondition(**kwds)]
+
+    track = basic_track.visibility_ge(target="track", measure="width", threshold=10)
+    kwds = dict(operation="GTET", target="track", measure="width", threshold=10)
+    assert track.visibility == [gos.VisibilityCondition(**kwds)]
+
+
+def test_track_composition(basic_track: gos.Track) -> None:
+    view = gos.overlay(basic_track.properties(width=500, height=10), basic_track)
+    assert isinstance(view, gos.View)
+    assert view.alignment == "overlay"
+    # uses width and height from first track
+    assert view.width == 500
+    assert view.height == 10
+    assert len(view.tracks) == 2
+
+    # override w/h at view-level
+    view = gos.overlay(
+        basic_track.properties(width=500, height=10),
+        basic_track.properties(width=10, height=40),
+        basic_track,
+        width=60,
+        height=60,
+    )
+    assert view.width == 60
+    assert view.height == 60
+    assert len(view.tracks) == 3
+    for track in view.tracks:
+        assert track.width == gos.Undefined
+        assert track.height == gos.Undefined
+
+    view = gos.stack(
+        basic_track.properties(width=50, height=50),
+        basic_track.properties(width=60, height=60),
+    )
+    assert isinstance(view, gos.View)
+    assert view.alignment == "stack"
+    assert len(view.tracks) == 2
+
+
+def test_view_composition(basic_track: gos.Track) -> None:
+
+    view = gos.horizontal(basic_track.view(), basic_track.view())
+    assert isinstance(view, gos.View)
+    assert view.arrangement == "horizontal"
+    assert len(view.views) == 2
+
+    view = gos.vertical(basic_track.view(), basic_track.view())
+    assert isinstance(view, gos.View)
+    assert view.arrangement == "vertical"
+    assert len(view.views) == 2
+
+    view = gos.serial(basic_track.view(), basic_track.view())
+    assert isinstance(view, gos.View)
+    assert view.arrangement == "serial"
+    assert len(view.views) == 2
+
+    view = gos.parallel(basic_track.view(), basic_track.view())
+    assert isinstance(view, gos.View)
+    assert view.arrangement == "parallel"
+    assert len(view.views) == 2
+
+    # works with both tracks and views
+    view = gos.serial(
+        basic_track.view(),
+        basic_track,
+        basic_track,
+        basic_track.view(),
+    )
+    assert isinstance(view, gos.View)
+    assert len(view.views) == 4
+    for v in view.views:
+        assert isinstance(v, gos.View)

--- a/gosling/tests/test_data.py
+++ b/gosling/tests/test_data.py
@@ -1,0 +1,14 @@
+import gosling.data as data
+
+
+def test_data():
+    url = "http://localhost:8080/data.csv"
+    assert data.csv(url) == {"type": "csv", "url": url}
+    assert data.bigwig(url) == {"type": "bigwig", "url": url}
+    assert data.beddb(url) == {"type": "beddb", "url": url}
+    assert data.vector(url) == {"type": "vector", "url": url}
+    assert data.multivec(url) == {"type": "multivec", "url": url}
+    assert data.bam(url, indexUrl=url) == {"type": "bam", "url": url, "indexUrl": url}
+
+    values = [{"x": 1, "y": 2}]
+    assert data.json(values) == {"type": "json", "values": values}

--- a/gosling/utils/core.py
+++ b/gosling/utils/core.py
@@ -19,6 +19,16 @@ def parse_shorthand(
     shorthand,
     parse_types=True,
 ):
+    """
+    >>> parse_shorthand('name') == {'field': 'name'}
+    True
+    >>> parse_shorthand('name:Q') == {'field': 'name', 'type': 'quantitative'}
+    True
+    >>> parse_shorthand('foo:G') == {'field': 'foo', 'type': 'genomic'}
+    True
+    >>> parse_shorthand('foo:N') == {'field': 'foo', 'type': 'nominal'}
+    True
+    """
     if not shorthand:
         return {}
 


### PR DESCRIPTION
Implements #34


I chose to use the corresponding aliases (`le` & `ge` instead of `ltet` and `gtet`) since these names correspond with python built-in dunder methods: https://docs.python.org/3/reference/datamodel.html#object.__lt__